### PR TITLE
[fix] 장바구니 날짜 변경 후 장바구니 내역, 날짜 리셋 추가

### DIFF
--- a/client/components/Cart/ReservationSetDT.jsx
+++ b/client/components/Cart/ReservationSetDT.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { cartReset } from '../../redux/modules/ReservationsCakeDetail';
+import { dtReset } from '../../redux/modules/ReservationsDT';
 
 function ReservationSetDT() {
   const navigate = useNavigate();
+  // 날짜 변경 시 disptch로 장바구니 리셋시키기
+  const dispatch = useDispatch();
 
   // 1. const ReservationSetTime = useSelector((state) => state.ReservationsDT.time)
   // 2.  {!ReservationSetTime.time || !ReservationSetlDate ? 이 부분에서  Cannot read properties of null (reading 'time')
@@ -30,6 +34,9 @@ function ReservationSetDT() {
       // 확인을 눌르면 모든 예약 정보 삭제
       localStorage.clear();
       navigate(`/Reservation`);
+      // 장바구니, 날짜 리셋
+      dispatch(cartReset());
+      dispatch(dtReset());
     }
   };
   return (


### PR DESCRIPTION
장바구니 페이지에서 날짜 변경 후 예약 페이지로 변경 되고 다시 장바구니 페이지를 들어가면 내역과 날짜가 리셋이 안되는 문제 발견, 장바구니 내역과 날짜 리셋을 추가하여 리셋되도록 코드를 추가하였다.